### PR TITLE
Wrong file paths when the site is in a subdirectory bug fixed

### DIFF
--- a/layout/base.jade
+++ b/layout/base.jade
@@ -6,6 +6,11 @@ if page.title
 else
   - var current_title = config.title
 
+if (config.root != '/')
+  - var root = config.root
+else
+  - var root = ''
+
 html
   head
     meta(http-equiv="content-type", content="text/html; charset=utf-8")
@@ -16,10 +21,10 @@ html
     meta(name="description", content=config.description)
     block title
     //+get_resource("blog_basic.css")
-    link(rel='stylesheet', type='text/css', href='/css/normalize.css')
-    link(rel='stylesheet', type='text/css', href='/css/pure-min.css')
-    link(rel='stylesheet', type='text/css', href='/css/grids-responsive-min.css')
-    link(rel='stylesheet', type='text/css', href='/css/style.css')
+    link(rel='stylesheet', type='text/css', href=root + '/css/normalize.css')
+    link(rel='stylesheet', type='text/css', href=root + '/css/pure-min.css')
+    link(rel='stylesheet', type='text/css', href=root + '/css/grids-responsive-min.css')
+    link(rel='stylesheet', type='text/css', href=root + '/css/style.css')
     link(rel='Shortcut Icon', type='image/x-icon',href='/favicon.ico')
     link(rel='apple-touch-icon', href='/apple-touch-icon.png')
     link(rel='apple-touch-icon-precomposed', href='/apple-touch-icon.png')
@@ -82,11 +87,11 @@ html
       |  by
       a(rel='nofollow', target='_blank', href='https://github.com/pagecho')  Cho.
 
-  != js(['/js/jquery.min.js', '/js/totop.js'])
+  != js([root + '/js/jquery.min.js', root + '/js/totop.js'])
 
     if theme.fancybox
-      != js(['/js/fancybox.pack.js'])
-      != css('/css/jquery.fancybox.css')
+      != js([root + '/js/fancybox.pack.js'])
+      != css(root + '/css/jquery.fancybox.css')
       script.
         $(document).ready(function() {
           $("img").wrap(function() {

--- a/source/css/style.scss
+++ b/source/css/style.scss
@@ -815,11 +815,11 @@ pre .javascript .function {
 /* IcoMoon*/
 @font-face {
 	font-family: 'icomoon';
-	src:url('/fonts/icomoon.eot?g43wbc');
-	src:url('/fonts/icomoon.eot?g43wbc#iefix') format('embedded-opentype'),
-		url('/fonts/icomoon.ttf?g43wbc') format('truetype'),
-		url('/fonts/icomoon.woff?g43wbc') format('woff'),
-		url('/fonts/icomoon.svg?g43wbc#icomoon') format('svg');
+	src:url('../fonts/icomoon.eot?g43wbc');
+	src:url('../fonts/icomoon.eot?g43wbc#iefix') format('embedded-opentype'),
+		url('../fonts/icomoon.ttf?g43wbc') format('truetype'),
+		url('../fonts/icomoon.woff?g43wbc') format('woff'),
+		url('../fonts/icomoon.svg?g43wbc#icomoon') format('svg');
 	font-weight: normal;
 	font-style: normal;
 }


### PR DESCRIPTION
css, js and font files had a wrong path when the site was put in a subdirectory,

e.g.

If the main hexo "_config.yml" file contains:

url: http://mysite.com/blog
root: /blog/

The path was something like:

  http://mysite.com/css/normalize.css

instead of:

  http://mysite.com/blog/css/normalize.css