### PR TITLE
Modify the style.css and fix some bugs.

### DIFF
--- a/source/css/style.scss
+++ b/source/css/style.scss
@@ -377,7 +377,6 @@ blockquote,.stressed {
     box-sizing: border-box;
     margin: 2.5em 0;
     padding: 0 0 0 50px;
-    font-style: italic;
     color: #555;
 	border-left: none;
 }
@@ -395,7 +394,7 @@ blockquote:before,.stressed-quote:before {
 }
 strong,b,em{
 	padding: 1px 2px;
-	font-weight: normal;
+	font-weight: bold;
 }
 pre{
 	margin:2em 0;


### PR DESCRIPTION
主要是调整两处css样式：

（1）修复Markdown语法渲染下的强调（strong）`**text**`语法无效，修改`font-weight: normal;`为`font-weight: bold;`，修改后效果大致如下（红色底线用于突出）：

![image](https://cloud.githubusercontent.com/assets/14356434/10916279/a9f8a41e-8295-11e5-9a5a-d85a515172d3.png)

（2）调整中文引用`quote`样式，不建议采用斜体排版中文字体，不够美观，另外也可参考[用斜体排版中文是否合适？](http://www.zhihu.com/question/20120243)。

修改后效果大致如下：

![image](https://cloud.githubusercontent.com/assets/14356434/10916329/ecaa6522-8295-11e5-9dd5-c5d626621163.png)

PS：或许可以参考下Github默认引用样式，显示效果不错，比如说这样：
 >测试文本

