### PR TITLE
fix bad title href when site is in a subdirectory

### DIFF
--- a/layout/base.jade
+++ b/layout/base.jade
@@ -33,7 +33,7 @@ html(lang='#{config.language}')
     #header
       .site-name
         h1.hidden= current_title
-        a#logo(href='/')= config.title
+        a#logo(href=root)= config.title
         p.description= config.subtitle
       #nav-menu
         - for (i in theme.menu)


### PR DESCRIPTION
when i deploy blog to the github, it's in a **/subdirectory**, but the blog's title always direct to the wrong '/'.