### PR TITLE
fix title href when site's root is /

### DIFF
--- a/layout/base.jade
+++ b/layout/base.jade
@@ -33,7 +33,7 @@ html(lang='#{config.language}')
     #header
       .site-name
         h1.hidden= current_title
-        a#logo(href=root)= config.title
+        a#logo(href=(root==''?'/':root))= config.title
         p.description= config.subtitle
       #nav-menu
         - for (i in theme.menu)


### PR DESCRIPTION
When site's root is "/", you make root = "", thus href=root is href="". And the title can not href to index