### PR TITLE
Changes about home href and feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ baidu_analytics: ## Your Baidu Analytics tracking id, e.g. 8006843039519956000
 
 menu:
   - page: home
-    directory: /
+    directory: .
     icon: icon-home
   - page: archive
     directory: archives/

--- a/layout/_partial/after_footer.jade
+++ b/layout/_partial/after_footer.jade
@@ -1,6 +1,6 @@
 if theme.fancybox
-  != js([root + 'js/fancybox.pack.js', root + 'js/jquery.fancybox.js'])
-  != css(root + 'css/jquery.fancybox.css')
+  != js([url_for('js/fancybox.pack.js'), url_for('js/jquery.fancybox.js')])
+  != css(url_for('css/jquery.fancybox.css'))
 
 if theme.duoshuo
   script.

--- a/layout/_partial/after_footer.jade
+++ b/layout/_partial/after_footer.jade
@@ -1,6 +1,6 @@
 if theme.fancybox
-  != js([root + '/js/fancybox.pack.js', root + '/js/jquery.fancybox.js'])
-  != css(root + '/css/jquery.fancybox.css')
+  != js([root + 'js/fancybox.pack.js', root + 'js/jquery.fancybox.js'])
+  != css(root + 'css/jquery.fancybox.css')
 
 if theme.duoshuo
   script.

--- a/layout/_partial/helpers.jade
+++ b/layout/_partial/helpers.jade
@@ -1,6 +1,6 @@
 mixin a_with_current(href, content, id)
   - var url = url_for(href)
-  if (href == '/' && (is_home() || is_post())) || is_current(href)
+  if (href == '.' && (is_home() || is_post())) || is_current(href)
     a.current(href=url)
       i(class=id)= ' ' + content
   else

--- a/layout/_partial/totop.jade
+++ b/layout/_partial/totop.jade
@@ -1,3 +1,3 @@
 a#rocket.show(href='#top')
 
-!= js([root + '/js/jquery.min.js', root + '/js/totop.js'])
+!= js([root + 'js/jquery.min.js', root + 'js/totop.js'])

--- a/layout/_partial/totop.jade
+++ b/layout/_partial/totop.jade
@@ -1,3 +1,3 @@
 a#rocket.show(href='#top')
 
-!= js([root + 'js/jquery.min.js', root + 'js/totop.js'])
+!= js([url_for('js/jquery.min.js'), url_for('js/totop.js')])

--- a/layout/base.jade
+++ b/layout/base.jade
@@ -33,7 +33,7 @@ html(lang='#{config.language}')
     #header
       .site-name
         h1.hidden= current_title
-        a#logo(href=(root==''?'/':root))= config.title
+        a#logo(href=url_for('.'))= config.title
         p.description= config.subtitle
       #nav-menu
         - for (var i in theme.menu)
@@ -47,7 +47,7 @@ html(lang='#{config.language}')
           != partial('_widget/' + item + '.jade')
 
     #footer= '© '
-      a(href='/', rel='nofollow')= config.title + '.'
+      a(href=url_for('.'), rel='nofollow')= config.title + '.'
       |  Powered by
       a(rel='nofollow', target='_blank', href='https://hexo.io')  Hexo.
       a(rel='nofollow', target='_blank', href='https://github.com/tufu9441/maupassant-hexo')  Theme

--- a/layout/base.jade
+++ b/layout/base.jade
@@ -5,11 +5,6 @@ if page.title
 else
   - var current_title = config.title
 
-if (config.root != '/')
-  - var root = config.root
-else
-  - var root = ''
-
 <!DOCTYPE html>
 html(lang='#{config.language}')
   head
@@ -20,14 +15,14 @@ html(lang='#{config.language}')
     meta(content='telephone=no', name='format-detection')
     meta(name='description', content=config.description)
     block title
-    link(rel='stylesheet', type='text/css', href=root + 'css/normalize.css')
-    link(rel='stylesheet', type='text/css', href=root + 'css/pure-min.css')
-    link(rel='stylesheet', type='text/css', href=root + 'css/grids-responsive-min.css')
-    link(rel='stylesheet', type='text/css', href=root + 'css/style.css')
-    link(rel='Shortcut Icon', type='image/x-icon',href='favicon.ico')
-    link(rel='apple-touch-icon', href='apple-touch-icon.png')
-    link(rel='apple-touch-icon-precomposed', href='apple-touch-icon.png')
-    link(rel='alternate', type='application/atom+xml', href='atom.xml')
+    link(rel='stylesheet', type='text/css', href=url_for('css/normalize.css'))
+    link(rel='stylesheet', type='text/css', href=url_for('css/pure-min.css'))
+    link(rel='stylesheet', type='text/css', href=url_for('css/grids-responsive-min.css'))
+    link(rel='stylesheet', type='text/css', href=url_for('css/style.css'))
+    link(rel='Shortcut Icon', type='image/x-icon',href=url_for('favicon.ico'))
+    link(rel='apple-touch-icon', href=url_for('apple-touch-icon.png'))
+    link(rel='apple-touch-icon-precomposed', href=url_for('apple-touch-icon.png'))
+    link(rel='alternate', type='application/atom+xml', href=url_for('atom.xml'))
 
   body: .body_container
     #header

--- a/layout/base.jade
+++ b/layout/base.jade
@@ -20,14 +20,14 @@ html(lang='#{config.language}')
     meta(content='telephone=no', name='format-detection')
     meta(name='description', content=config.description)
     block title
-    link(rel='stylesheet', type='text/css', href=root + '/css/normalize.css')
-    link(rel='stylesheet', type='text/css', href=root + '/css/pure-min.css')
-    link(rel='stylesheet', type='text/css', href=root + '/css/grids-responsive-min.css')
-    link(rel='stylesheet', type='text/css', href=root + '/css/style.css')
-    link(rel='Shortcut Icon', type='image/x-icon',href='/favicon.ico')
-    link(rel='apple-touch-icon', href='/apple-touch-icon.png')
-    link(rel='apple-touch-icon-precomposed', href='/apple-touch-icon.png')
-    link(rel='alternate', type='application/atom+xml', href='/atom.xml')
+    link(rel='stylesheet', type='text/css', href=root + 'css/normalize.css')
+    link(rel='stylesheet', type='text/css', href=root + 'css/pure-min.css')
+    link(rel='stylesheet', type='text/css', href=root + 'css/grids-responsive-min.css')
+    link(rel='stylesheet', type='text/css', href=root + 'css/style.css')
+    link(rel='Shortcut Icon', type='image/x-icon',href='favicon.ico')
+    link(rel='apple-touch-icon', href='apple-touch-icon.png')
+    link(rel='apple-touch-icon-precomposed', href='apple-touch-icon.png')
+    link(rel='alternate', type='application/atom+xml', href='atom.xml')
 
   body: .body_container
     #header

--- a/layout/base.jade
+++ b/layout/base.jade
@@ -5,7 +5,14 @@ if page.title
 else
   - var current_title = config.title
 
-<!DOCTYPE html>
+case config.feed.type
+  when "rss2"
+    - var feed_type='application/rss+xml'
+  when "atom"
+  default
+    - var feed_type='application/atom+xml'
+
+doctype html
 html(lang='#{config.language}')
   head
     meta(http-equiv='content-type', content='text/html; charset=utf-8')
@@ -22,7 +29,8 @@ html(lang='#{config.language}')
     link(rel='Shortcut Icon', type='image/x-icon',href=url_for('favicon.ico'))
     link(rel='apple-touch-icon', href=url_for('apple-touch-icon.png'))
     link(rel='apple-touch-icon-precomposed', href=url_for('apple-touch-icon.png'))
-    link(rel='alternate', type='application/atom+xml', href=url_for('atom.xml'))
+    if config.feed
+      link(rel='alternate', type=feed_type, href=url_for(config.feed.path))
 
   body: .body_container
     #header


### PR DESCRIPTION
Both d563f10 and 58a8d85 tried to fix the link to root (i.e. home page), but that ternary is unnecessary.
And they missed out the link in the nav-menu, footer and path of all the resources files. With a prefix slash they all break when the blog lives in a sub-directory.
Replacing the `root + path` approach with `url_for()` helper as required by [official doc](https://hexo.io/docs/helpers.html#url_for) should makes things clear.

To see what the different hrefs bring us to, see http://rmntn.net/href-test

I also make RSS feed header self-adaptive.

PS. crap, just found out there's a typo in the commit message.