### PR TITLE
Make comment feature default on for pages while controllable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ You can control the abstract of a post shown at index, by either filling a `desc
 #### Table of Contents
 TOC in a post can be enabled by adding a `toc: true` item in `front-matter`.
 
+#### Comments
+Comment feature of each post and page can be enabled (default) and disabled by adding a `comments: true` or `comments: false` in `front-matter`. This could be useful when you want comment feature for guestbook page, but don't want comment feature for about page.
+
 #### Syntax Highlighting
 Highlighted code showcase is supported, please set the `highlight` option in `_config.yml` of hexo directory like this:
 

--- a/layout/page.jade
+++ b/layout/page.jade
@@ -6,4 +6,5 @@ block content
     h1.post-title= page.title
     .post-content
       != page.content
-
+    if page.comments
+      include _partial/comments


### PR DESCRIPTION
Before this change, page layout won't insert comment code, which makes new users very confused when trying to add a guestbook page with comment feature.

Now it is much easier to add it instead of writing raw manual html in markdown (which actually I never succeeded after trying hours), and also controllable by "comments: true/false" in front-matter.