### PR TITLE
Add math equation support for hexo

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,35 @@ highlight:
 #### Languages
 Seven languages are available for this theme currently: Simplified Chinese (zh-CN), Traditional Chinese (zh-TW), English (en), French (fr-FR), German (de-DE), Korean (ko) and Spanish (es-ES). Contributions of translating to other languages will be highly appreciated.
 
+### Math Equation
+Add
+```
+mathjax: true
+```
+in hexo's `_config.yml`.
+
+In the post that you would like to use math equation, add `mathjax: true`. For example:
+
+```
+---
+title: Test Math
+date: 2016-04-05 14:16:00
+categories:
+- math
+mathjax: true
+---
+```
+The default math delimiters are `$$...$$` and `\\[...\\]` for displayed mathematics,
+and `$...$` and `\\(...\\)` for in-line mathematics.
+
+In addition, if your post contains dollar signs (`$`) appear too often in non-mathematical settings, please add
+
+```
+mathjax2: true
+```
+in hexo's `_config.yml` instead of `mathjax: true`. Correspondingly, add `mathjax2: true` to the post header in which
+you would like to use math equation.
+
 ## Solutions
 - Check whether your Terminal's current directory is in hexo's root directory which contains `source/`, `themes/`, etc.
 

--- a/README.md
+++ b/README.md
@@ -144,13 +144,15 @@ mathjax: true
 The default math delimiters are `$$...$$` and `\\[...\\]` for displayed mathematics,
 and `$...$` and `\\(...\\)` for in-line mathematics.
 
-In addition, if your post contains dollar signs (`$`) appear too often in non-mathematical settings, please add
+In addition, if your post contains dollar signs (`$`) appear too often in non-mathematical settings. In other words, you want to use `$` as dollar sign, not inline math delimiter. Please add
 
 ```
 mathjax2: true
 ```
 in hexo's `_config.yml` instead of `mathjax: true`. Correspondingly, add `mathjax2: true` to the post header in which
 you would like to use math equation.
+
+see the [example](http://zhongpu.info/2016/05/06/Mathjax%20and%20Hexo/).
 
 ## Solutions
 - Check whether your Terminal's current directory is in hexo's root directory which contains `source/`, `themes/`, etc.

--- a/layout/_partial/after_footer.jade
+++ b/layout/_partial/after_footer.jade
@@ -69,5 +69,11 @@ if theme.baidu_analytics
       s.parentNode.insertBefore(hm, s);
       })();
 
+if page.mathjax
+  include mathjax
+
+if page.mathjax2
+    include mathjax2
+    
 script(type='text/javascript', src=url_for(theme.js) + '/codeblock-resizer.js' + '?v=' + theme.version)
 script(type='text/javascript', src=url_for(theme.js) + '/smartresize.js' + '?v=' + theme.version)

--- a/layout/_partial/mathjax.jade
+++ b/layout/_partial/mathjax.jade
@@ -1,0 +1,6 @@
+script(type='text/x-mathjax-config').
+  MathJax.Hub.Config({
+    tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+    });
+
+script(type='text/javascript', src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML', async)

--- a/layout/_partial/mathjax2.jade
+++ b/layout/_partial/mathjax2.jade
@@ -1,0 +1,1 @@
+script(type='text/javascript', src='https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML', async)


### PR DESCRIPTION
Add math equation support for hexo taking the advantage of mathjax.

I have deployed it at my blogs, see http://zhongpu.info/2016/05/06/Mathjax%20and%20Hexo/