### PR TITLE
add google ad support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ version: 0.0.0
 - baidu_analytics - [Baidu Analytics](http://tongji.baidu.com) tracking id
 - shareto - Enable share button
 - busuanzi - Enable [Busuanzi](http://busuanzi.ibruce.info) page views
-- google_hub, google_ad_slot - Enable [Google AdSense](google_hub) at footer
+- google_hub, google_ad_slot - Enable [Google AdSense](www.google.com/AdSense) at footer
 - menu - Customize your menu of pages here, just follow the format of existied items. Don't forget to create corresponding folders inlcuding `index.md` in `source` folder to ensure the pages will correctly display. [FontAwesome](http://fontawesome.io) icon fonts have been integrated, and you can choose other icons you like [here](http://fontawesome.io/icons/) and use them according to the instruction.
 - widgets - Choose and arrange the widgets in sidebar here.
 - links - Edit your blogroll here.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ google_analytics: ## Your Google Analytics tracking id, e.g. UA-42425684-2
 baidu_analytics: ## Your Baidu Analytics tracking id, e.g. 8006843039519956000
 shareto: true ## If you want to use the share button please set the value to true.
 busuanzi: true ## If you want to use Busuanzi page views please set the value to true.
+google_hub: ## Your Google pub id, e.g. pub-6877037964485253
+google_ad_slot: ## Your Google Ad unit id, e.g. 7233298824
 
 menu:
   - page: home
@@ -88,11 +90,17 @@ version: 0.0.0
 - baidu_analytics - [Baidu Analytics](http://tongji.baidu.com) tracking id
 - shareto - Enable share button
 - busuanzi - Enable [Busuanzi](http://busuanzi.ibruce.info) page views
+- google_hub, google_ad_slot - Enable [Google AdSense](google_hub) at footer
 - menu - Customize your menu of pages here, just follow the format of existied items. Don't forget to create corresponding folders inlcuding `index.md` in `source` folder to ensure the pages will correctly display. [FontAwesome](http://fontawesome.io) icon fonts have been integrated, and you can choose other icons you like [here](http://fontawesome.io/icons/) and use them according to the instruction.
 - widgets - Choose and arrange the widgets in sidebar here.
 - links - Edit your blogroll here.
 - Static files - Static files directory, for convenience of CDN usage.
 - Theme version - For automatic refresh of static files on CDN.
+
+### Note for Google AdSense
+- The `AdBlock` plugin (or something like that) may disable Google Ad
+- The first time when you did config for `google_hub` and `google_ad_slot`, it may caused `Bad Request (400)` error. Don't worry about it, just reload the web page multiple times. see more at [400 Bad Request with Google AdSense](http://stackoverflow.com/questions/19139171/400-bad-request-with-google-adsense)
+- The Google Ad is at the position of footer part by default. Hence don't delete the `footer.jade` file.
 
 ## Features
 #### Logo

--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,8 @@ google_analytics: ## Your Google Analytics tracking id, e.g. UA-42425684-2
 baidu_analytics: ## Your Baidu Analytics tracking id, e.g. 8006843039519956000
 shareto: true ## If you want to use the share button please set the value to true.
 busuanzi: true ## If you want to use Busuanzi page views please set the value to true.
+google_hub: ## Your Google pub id, e.g. pub-6877037964485253
+google_ad_slot: ## Your Google Ad unit id, e.g. 7233298824
 
 menu:
   - page: home

--- a/layout/_partial/footer.jade
+++ b/layout/_partial/footer.jade
@@ -1,3 +1,5 @@
+include google_ad
+
 #footer= '© '
   a(href=url_for('.'), rel='nofollow')= config.title + '.'
   |  Powered by

--- a/layout/_partial/google_ad.jade
+++ b/layout/_partial/google_ad.jade
@@ -1,0 +1,5 @@
+if theme.google_hub
+  script(type='text/javascript', src='//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js', async)
+  ins(class='adsbygoogle', style='display:block', data-ad-client='ca-#{theme.google_hub}', data-ad-slot='#{theme.google_ad_slot}', data-ad-format='auto')
+  script.
+    (adsbygoogle = window.adsbygoogle || []).push({})


### PR DESCRIPTION
Add the Google Adsense support for Hexo.

The Google Ad is at the the position of `footer` by default. I have deployed it in my blog: http://zhongpu.info/

The `README.md` also specifies the notes for Google Ad:

```YAML
google_hub: ## Your Google pub id, e.g. pub-6877037964485253
google_ad_slot: ## Your Google Ad unit id, e.g. 7233298824
```