### PR TITLE
原函数stringObject.substr(start,length)用法出错

### DIFF
--- a/source/js/search.js
+++ b/source/js/search.js
@@ -55,12 +55,9 @@ var searchFunc = function(path, search_id, content_id) {
                         if (first_occur >= 0) {
                             // cut out 100 characters
                             var start = first_occur - 20;
-                            var end = first_occur + 20;
+                            var end = 40;
                             if(start < 0){
                                 start = 0;
-                            }
-                            if(start == 0){
-                                end = 40;
                             }
                             if(end > content.length){
                                 end = content.length;


### PR DESCRIPTION
原函数若搜索到在一篇博文的100001的地方有关键词，first_occur=100000，start=99980，end=100020，将会输出从99981到200001位置的全部字符总计100020个，将页面完全撑爆！