### PR TITLE
QR code generation without jiathis.com.

### DIFF
--- a/layout/post.jade
+++ b/layout/post.jade
@@ -39,7 +39,7 @@ block content
       != page.content
     if theme.shareto == true
       script(type='text/javascript', src=url_for(theme.js) + '/share.js' + '?v=' + theme.version, async)
-      a.article-share-link(data-url='#{page.permalink}', data-id='#{page._id}')= __('shareto')
+      a.article-share-link(data-url='#{page.permalink}', data-id='#{page._id}', data-qrcode=qrcode(page.permalink))= __('shareto')
     include _partial/tag
     include _partial/post_nav
     if theme.duoshuo

--- a/source/css/style.scss
+++ b/source/css/style.scss
@@ -1803,21 +1803,21 @@ table {
   }
 }
 
-.article-share-wechat {
+.article-share-qrcode {
   @extend .article-share-element;
   &:before {
-    content: "\f1d7";
+    content: "\f029";
   }
-  &:hover {
+  &:hover, &:active {
     background: #38ad5a;
-    &~ .wechat-qrcode {
+    &~ .qrcode {
       display: block;
       text-align: center;
     }
   }
 }
 
-.wechat-qrcode {
+.qrcode {
   display: none;
 }
 

--- a/source/js/share.js
+++ b/source/js/share.js
@@ -8,6 +8,7 @@
 
     var $this = $(this),
       url = $this.attr('data-url'),
+      qrcode_img = $this.attr('data-qrcode'),
       encodedUrl = encodeURIComponent(url),
       id = 'article-share-box-' + $this.attr('data-id'),
       title = document.title,
@@ -25,11 +26,11 @@
         '<div id="' + id + '" class="article-share-box">',
           '<input class="article-share-input" value="' + url + '">',
           '<div class="article-share-links">',
-            '<a href="https://twitter.com/intent/tweet?url=' + encodedUrl + '" class="article-share-twitter" target="_blank" title="Twitter"></a>',
-            '<a href="https://www.facebook.com/sharer.php?u=' + encodedUrl + '" class="article-share-facebook" target="_blank" title="Facebook"></a>',
-            '<a href="http://service.weibo.com/share/share.php?title=' + title + '&url=' + encodedUrl + '&searchPic=true&style=number' + '" class="article-share-weibo" target="_blank" title="Weibo"></a>',
-            '<a href="javascript:void(0);" class="article-share-wechat" target="_blank" title="Wechat"></a>',
-            '<div class="wechat-qrcode"><img src="http://s.jiathis.com/qrcode.php?url=' + encodedUrl + '"></div>',
+            '<a href="//twitter.com/intent/tweet?url=' + encodedUrl + '" class="article-share-twitter" target="_blank" title="Twitter"></a>',
+            '<a href="//www.facebook.com/sharer.php?u=' + encodedUrl + '" class="article-share-facebook" target="_blank" title="Facebook"></a>',
+            '<a href="//service.weibo.com/share/share.php?title=' + title + '&url=' + encodedUrl + '&searchPic=true&style=number' + '" class="article-share-weibo" target="_blank" title="Weibo"></a>',
+            '<a href="' + qrcode_img + '" class="article-share-qrcode" target="_blank" title="QR code"></a>',
+            '<div class="qrcode"><img src=' + qrcode_img + '></div>',
           '</div>',
         '</div>'
       ].join('');


### PR DESCRIPTION
You must have `hexo-helper-qrcode` installed.

Previously the QR code generation was based on the service of jiathis.com which does not support HTTPS. This shortcoming makes the QR code function not work in HTTPS site. Now the QR is generated by hexo so that the dependency of jiathis.com is removed.

之前的代码使用jiathis.com网站提供的服务生成二维码，但这个服务不支持HTTPS。现在的代码使用hexo-helper-qrcode来生成二维码，不再依赖iathis.com。

其他几个分享代码也编辑了一下。