### PR TITLE
添加gitalk/leancloud统计/不蒜子站点统计

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ gitment:
   repo: ## The repository to store your comments, make sure you're the repo's owner, e.g. imsun.github.io
   client_id: ## GitHub client ID, e.g. 75752dafe7907a897619
   client_secret: ## GitHub client secret, e.g. ec2fb9054972c891289640354993b662f4cccc50
+gitalk:
+  enable: false ## If you want to use Gitment comment system please set the value to true.
+  owner:  ## Your GitHub ID, e.g. username
+  repo:  ## The repository to store your comments, make sure you're the repo's owner, e.g. imsun.github.io
+  client_id:  ## GitHub client ID, e.g. 75752dafe7907a897619
+  client_secret:  ## GitHub client secret, e.g. ec2fb9054972c891289640354993b662f4cccc50
+  admin:  ## Github repo owner and collaborators, only these guys can initialize github issues'
 uyan: ## Your uyan_id. e.g. 1234567
 livere: ## Your livere data-uid, e.g. MTAyMC8zMDAxOC78NTgz
 changyan: ## Your changyan appid, e.g. cyrALsXc8
@@ -59,8 +66,15 @@ baidu_analytics: ## Your Baidu Analytics tracking id, e.g. 8006843039519956000
 show_category_count: false ## If you want to show the count of categories in the sidebar widget please set the value to true.
 toc_number: true ## If you want to add list number to toc please set the value to true.
 shareto: false ## If you want to use the share button please set the value to true, you must have hexo-helper-qrcode installed.
-busuanzi: false ## If you want to use Busuanzi page views please set the value to true.
-widgets_on_small_screens: false ## Set to true to enable widgets on small screens.
+busuanzi:
+  enable: false ## If you want to use Busuanzi please set the value to true.
+  page_pv: true ## If you want to use Busuanzi single page views please set the value to true.
+  site_pv: true ## If you want to use Busuanzi site total views please set the value to true.
+  site_uv: true ## If you want to use Busuanzi site unique views please set the value to true.
+leancloud:
+  enable: false ## If you want to use leancloud page views please set the value to true.
+  appid:  ## Your LeanCloud application App ID, e.g. pRBBL2JR4N7kLEGojrF0MsSs-gzGzoHsz
+  appkey:  ## Your LeanCloud application App Key, e.g. tjczHpDfhjYDSYddzymYK1JJwidgets_on_small_screens: false ## Set to true to enable widgets on small screens.
 canvas_nest:
   enable: false ## If you want to use dynamic background please set the value to true, you can also fill the following parameters to customize the dynamic effect, or just leave them blank to keep the default effect.
   color: ## RGB value of the color, e.g. "100,99,98"
@@ -126,6 +140,7 @@ version: 0.0.0
 - fancybox - Enable [Fancybox](http://fancyapps.com/fancybox/)
 - disqus - [Disqus](https://disqus.com) shortname
 - gitment - [Gitment](https://github.com/imsun/gitment) comment system
+- gitalk - [Gitalk](https://github.com/gitalk/gitalk) issue comment system
 - uyan - [Uyan](http://www.uyan.cc) id
 - livere - [LiveRe](https://livere.com) data-uid
 - changyan - [Changyan](http://changyan.kuaizhan.com) appid
@@ -141,6 +156,7 @@ version: 0.0.0
 - toc_number - Show the list number of toc
 - shareto - Enable share button, with the dependency on the plugin [hexo-helper-qrcode](https://github.com/yscoder/hexo-helper-qrcode)
 - busuanzi - Enable [Busuanzi](http://busuanzi.ibruce.info) page views
+- leancloud - Enable [LeanCloud](https://leancloud.cn/) page views
 - widgets_on_small_screens - Show the widgets at the bottom of small screens
 - [canvas_nest](https://github.com/hustcc/canvas-nest.js) - Enable dynamic background
 - donate - Enable donate button after each post

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ baidu_analytics: ## Your Baidu Analytics tracking id, e.g. 8006843039519956000
 show_category_count: false ## If you want to show the count of categories in the sidebar widget please set the value to true.
 toc_number: true ## If you want to add list number to toc please set the value to true.
 shareto: false ## If you want to use the share button please set the value to true, you must have hexo-helper-qrcode installed.
+widgets_on_small_screens: false ## Set to true to enable widgets on small screens.
 busuanzi:
   enable: false ## If you want to use Busuanzi please set the value to true.
   page_pv: true ## If you want to use Busuanzi single page views please set the value to true.

--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,13 @@ gitment:
   repo: ## The repository to store your comments, make sure you're the repo's owner, e.g. imsun.github.io
   client_id: ## GitHub client ID, e.g. 75752dafe7907a897619
   client_secret: ## GitHub client secret, e.g. ec2fb9054972c891289640354993b662f4cccc50
+gitalk:
+  enable: false ## If you want to use Gitment comment system please set the value to true.
+  owner:  ## Your GitHub ID, e.g. username
+  repo:  ## The repository to store your comments, make sure you're the repo's owner, e.g. imsun.github.io
+  client_id:  ## GitHub client ID, e.g. 75752dafe7907a897619
+  client_secret:  ## GitHub client secret, e.g. ec2fb9054972c891289640354993b662f4cccc50
+  admin:  ## Github repo owner and collaborators, only these guys can initialize github issues'
 uyan: ## Your uyan_id. e.g. 1234567
 livere: ## Your livere data-uid, e.g. MTAyMC8zMDAxOC78NTgz
 changyan: ## Your changyan appid, e.g. cyrALsXc8
@@ -31,7 +38,16 @@ baidu_analytics: ## Your Baidu Analytics tracking id, e.g. 8006843039519956000
 show_category_count: false ## If you want to show the count of categories in the sidebar widget please set the value to true.
 toc_number: true ## If you want to add list number to toc please set the value to true.
 shareto: false ## If you want to use the share button please set the value to true, you must have hexo-helper-qrcode installed.
-busuanzi: false ## If you want to use Busuanzi page views please set the value to true.
+busuanzi:
+  enable: false ## If you want to use Busuanzi please set the value to true.
+  page_pv: true ## If you want to use Busuanzi single page views please set the value to true.
+  site_pv: true ## If you want to use Busuanzi site total views please set the value to true.
+  site_uv: true ## If you want to use Busuanzi site unique views please set the value to true.
+leancloud:
+  enable: false ## If you want to use leancloud page views please set the value to true.
+  appid:  ## Your LeanCloud application App ID, e.g. pRBBL2JR4N7kLEGojrF0MsSs-gzGzoHsz
+  appkey:  ## Your LeanCloud application App Key, e.g. tjczHpDfhjYDSYddzymYK1JJ
+  class:  ## Your LeanCloud application Storage Class, e.g. Counter
 widgets_on_small_screens: false ## Set to true to enable widgets on small screens.
 canvas_nest:
   enable: false ## If you want to use dynamic background please set the value to true, you can also fill the following parameters to customize the dynamic effect, or just leave them blank to keep the default effect.

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -23,3 +23,5 @@ shareto: Share
 Discuss: Discuss
 Comment: Comment
 Hits: Hits
+page_views: Page Views
+visitors: Visitors

--- a/languages/zh-CN.yml
+++ b/languages/zh-CN.yml
@@ -23,3 +23,5 @@ shareto: 分享
 Discuss: 条参与
 Comment: 条评论
 Hits: 阅读
+page_views: 访问量
+visitors: 访客数

--- a/languages/zh-TW.yml
+++ b/languages/zh-TW.yml
@@ -23,3 +23,5 @@ shareto: 分享
 Discuss: 條參與
 Comment: 條評論
 Hits: 閱讀
+page_views: 訪問量
+visitors: 訪客數

--- a/layout/_partial/comments.pug
+++ b/layout/_partial/comments.pug
@@ -13,6 +13,21 @@ if theme.gitment.enable == true
       })
       gitment.render('container')
 
+if theme.gitalk.enable == true
+    #container
+    link(rel='stylesheet', type='text/css', href='//unpkg.com/gitalk/dist/gitalk.css?v=' + theme.version)
+    script(type='text/javascript' src='//unpkg.com/gitalk/dist/gitalk.min.js?v=' + theme.version)
+    script.
+      var gitalk = new Gitalk({
+        clientID: '#{theme.gitalk.client_id}',
+        clientSecret: '#{theme.gitalk.client_secret}',
+        repo: '#{theme.gitalk.repo}',
+        owner: '#{theme.gitalk.owner}',
+        admin: ['#{theme.gitalk.admin}'],
+        distractionFreeMode: false
+      })
+      gitalk.render('container')
+      
 if theme.disqus
   #disqus_thread
     .btn_click_load

--- a/layout/_partial/footer.pug
+++ b/layout/_partial/footer.pug
@@ -5,3 +5,24 @@
   a(rel='nofollow', target='_blank', href='https://github.com/tufu9441/maupassant-hexo')  Theme
   |  by
   a(rel='nofollow', target='_blank', href='https://github.com/pagecho')  Cho.
+  if theme.busuanzi.enable == true
+    script(src='https://dn-lbstatics.qbox.me/busuanzi/2.3/busuanzi.pure.mini.js', async)
+    if theme.busuanzi.site_pv == true
+      span#busuanzi_container_site_pv= ' | ' + __('page_views')
+        span#busuanzi_value_site_pv
+    if theme.busuanzi.site_uv == true
+      span#busuanzi_container_site_uv= ' | ' + __('visitors')
+        span#busuanzi_value_site_uv
+  if theme.leancloud.enable == true
+    script(src='https://cdn1.lncld.net/static/js/av-core-mini-0.6.4.js')
+    script(type='text/javascript', src=url_for(theme.js) + '/leancloud.js' + '?v=' + theme.version)
+    script.
+      AV.initialize('#{theme.leancloud.appid}', '#{theme.leancloud.appkey}')
+      $(function() {
+          var Counter = AV.Object.extend("Counter");
+          if ($('.leancloud-post').length > 0) {
+              addCount(Counter);
+          } else if ($('.leancloud-visitor').length > 0) {
+              showTime(Counter);
+          }
+      });

--- a/layout/index.pug
+++ b/layout/index.pug
@@ -14,6 +14,11 @@ block content
         a(href=url_for(post.path))
           +title(post)
       .post-meta= post.date.format(config.date_format)
+        if theme.leancloud.enable == true
+          span= ' | '
+            span(id='/' + post.path data-flag-title=post.title).leancloud-visitor.counter
+              span.leancloud-count
+              span= ' ' + __('Hits')
       if theme.disqus
         a.disqus-comment-count(data-disqus-identifier=post.path, href=url_for(post.path) + '#disqus_thread')
       if theme.changyan

--- a/layout/post.pug
+++ b/layout/post.pug
@@ -12,11 +12,15 @@ block content
         span.category
           for category in page.categories.toArray()
             a(href=url_for(category.path))= category.name
-      if theme.busuanzi == true
-        script(src='https://dn-lbstatics.qbox.me/busuanzi/2.3/busuanzi.pure.mini.js', async)
+      if theme.busuanzi.enable == true && theme.busuanzi.page_pv == true && theme.leancloud.enable == false
         span#busuanzi_container_page_pv= ' | '
           span#busuanzi_value_page_pv
           span= ' ' + __('Hits')
+      if theme.leancloud.enable == true
+        span= ' | '
+          span(id='/' + page.path data-flag-title=page.title).leancloud-post.leancloud-visitor.counter
+            span.leancloud-count
+            span= ' ' + __('Hits')
     if theme.disqus
       a.disqus-comment-count(data-disqus-identifier=page.path, href=url_for(page.path) + '#disqus_thread')
     if theme.changyan
@@ -27,7 +31,7 @@ block content
     if theme.valine.enable
       a.disqus-comment-count( href=url_for(page.path) + '#vcomment')
         span.valine-comment-count(data-xid=url_for(page.path))
-        span 条评论
+        span = ' ' + __('Comment')
     if page.toc
       div(class='clear')
         div(id='toc' class='toc-article')

--- a/source/css/style.scss
+++ b/source/css/style.scss
@@ -218,6 +218,16 @@ div {
               padding-right: 0.3em;
             }
         }
+        .counter {
+            &:before {
+              font-family: "FontAwesome";
+              content: "\f024";
+              padding-right: 0.3em;
+            }
+        }
+        .leancloud-count{
+            padding-right: 0.3em;
+        }
         #busuanzi_value_page_pv {
             &:before {
               font-family: "FontAwesome";
@@ -407,6 +417,7 @@ div {
     text-align: center;
     span {
         font-size: .9em;
+        padding: .3em;
     }
 }
 

--- a/source/js/leancloud.js
+++ b/source/js/leancloud.js
@@ -1,0 +1,89 @@
+function showTime(Counter) {
+    var query = new AV.Query(Counter);
+    var entries = [];
+    var $visitors = $(".leancloud-visitor");
+
+    $visitors.each(function() {
+        entries.push($(this).attr("id").trim());
+    });
+    query.containedIn('url', entries);
+    query.find()
+        .done(function(results) {
+            var COUNT_CONTAINER_REF = '.leancloud-count';
+
+            if (results.length === 0) {
+                $visitors.find(COUNT_CONTAINER_REF).text(0);
+                return;
+            }
+
+            for (var i = 0; i < results.length; i++) {
+                var item = results[i];
+                var url = item.get('url');
+                var time = item.get('time');
+                var element = document.getElementById(url);
+
+                $(element).find(COUNT_CONTAINER_REF).text(time);
+            }
+            for (var i = 0; i < entries.length; i++) {
+                var url = entries[i];
+                var element = document.getElementById(url);
+                var countSpan = $(element).find(COUNT_CONTAINER_REF);
+                if (countSpan.text() == '') {
+                    countSpan.text(0);
+                }
+            }
+        })
+        .fail(function(object, error) {
+            console.log("Error: " + error.code + " " + error.message);
+        });
+}
+
+function addCount(Counter) {
+    var $visitors = $(".leancloud-visitor");
+    var url = $visitors.attr('id').trim();
+    var title = $visitors.attr('data-flag-title').trim();
+    var query = new AV.Query(Counter);
+
+    query.equalTo("url", url);
+    query.find({
+        success: function(results) {
+            if (results.length > 0) {
+                var counter = results[0];
+                counter.fetchWhenSave(true);
+                counter.increment("time");
+                counter.save(null, {
+                    success: function(counter) {
+                        var $element = $(document.getElementById(url));
+                        $element.find('.leancloud-count').text(counter.get('time'));
+                    },
+                    error: function(counter, error) {
+                        console.log('Failed to save Visitor num, with error message: ' + error.message);
+                    }
+                });
+            } else {
+                var newcounter = new Counter();
+                /* Set ACL */
+                var acl = new AV.ACL();
+                acl.setPublicReadAccess(true);
+                acl.setPublicWriteAccess(true);
+                newcounter.setACL(acl);
+                /* End Set ACL */
+                newcounter.set("title", title);
+                newcounter.set("url", url);
+                newcounter.set("time", 1);
+                newcounter.save(null, {
+                    success: function(newcounter) {
+                        var $element = $(document.getElementById(url));
+                        $element.find('.leancloud-count').text(newcounter.get('time'));
+                    },
+                    error: function(newcounter, error) {
+                        console.log('Failed to create');
+                    }
+                });
+            }
+        },
+        error: function(error) {
+            console.log('Error:' + error.code + " " + error.message);
+        }
+    });
+}


### PR DESCRIPTION
## 特性添加
---
`gitalk` 支持
`LeanCLoud`文章浏览统计，可以在首页和详情页显示
`不蒜子`站点统计，在页脚显示
修改的内容详情在[这里](https://blog.f2e.fun/2018/add-leancloud-busuanzi-and-gitalk-to-hexo/)
大佬酌情merge, 看看需不需要这些功能