### PR TITLE
修复没有正确的比较导致valine评论系统notify和verify不能得到正确的设置

### DIFF
--- a/layout/_partial/comments.pug
+++ b/layout/_partial/comments.pug
@@ -114,8 +114,8 @@ if theme.valine.enable == true
     script(src='//cdn1.lncld.net/static/js/3.0.4/av-min.js')
     script(src='//unpkg.com/valine@latest/dist/Valine.min.js')
     script.
-      var notify = '#{ theme.valine.notify }' == true ? true : false;
-      var verify = '#{ theme.valine.verify }' == true ? true : false;
+      var notify = '#{ theme.valine.notify }' ? true : false;
+      var verify = '#{ theme.valine.verify }' ? true : false;
       var GUEST_INFO = ['nick','mail','link'];
       var guest_info = '#{ theme.valine.guest_info }'.split(',').filter(function(item){
         return GUEST_INFO.indexOf(item) > -1


### PR DESCRIPTION
原代码渲染之后的结果:
```
var notify = 'true' ? true : false;
var verify = 'true' ? true : false;
```
可以看出，这没有正确的比较