### PR TITLE
valine配置

### DIFF
--- a/layout/_partial/comments.pug
+++ b/layout/_partial/comments.pug
@@ -98,8 +98,8 @@ if theme.valine.enable == true
     script(src='//cdn1.lncld.net/static/js/3.0.4/av-min.js')
     script(src='//unpkg.com/valine@latest/dist/Valine.min.js')
     script.
-      var notify = '#{ theme.valine.notify }' ? true : false;
-      var verify = '#{ theme.valine.verify }' ? true : false;
+      var notify = '#{ theme.valine.notify }' == 'true' ? true : false;
+      var verify = '#{ theme.valine.verify }' == 'true' ? true : false;
       var GUEST_INFO = ['nick','mail','link'];
       var guest_info = '#{ theme.valine.guest_info }'.split(',').filter(function(item){
         return GUEST_INFO.indexOf(item) > -1


### PR DESCRIPTION
除非置空，否则theme.valine.verify设置false也会打开验证码。
在我自己电脑测试通过(Win10 Chrome 80)