### PR TITLE
Add option to disable to-top rocket ship

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ plantuml: ## Using PlantUML to generate UML diagram, must install hexo-filter-pl
     outputFormat: "svg" ## common options: svg/png
 copycode: true ## If you want to enable one-click copy of the code blocks, set the value to true.
 dark: false ## If you want to use the dark mode theme, set the value to true. Note: This feature is not complete, please open an issue if you have any problem.
+totop: true ## If you want the to-top rocketship, set the value to true.
 
 menu:
   - page: home

--- a/_config.yml
+++ b/_config.yml
@@ -73,6 +73,7 @@ plantuml: ## Using PlantUML to generate UML diagram, must install hexo-filter-pl
     outputFormat: "svg" ## Common options: svg/png
 copycode: true ## If you want to enable one-click copy of the code blocks, set the value to true.
 dark: false ## If you want to use the dark mode theme, set the value to true. Note: This feature is not complete, please open an issue if you have any problem.
+totop: true ## If you want the to-top rocketship, set the value to true.
 
 menu:
   - page: home

--- a/_config.yml
+++ b/_config.yml
@@ -89,7 +89,7 @@ menu:
     directory: atom.xml
     icon: fa-rss
 
-widgets: ## Six widgets in sidebar provided: search, category, tag, recent_posts, rencent_comments and links.
+widgets: ## Six widgets in sidebar provided: search, category, tag, recent_posts, recent_comments and links.
   - search
   - category
   - tag

--- a/layout/base-without-sidebar.pug
+++ b/layout/base-without-sidebar.pug
@@ -34,5 +34,6 @@ html(lang=config.language)
       .pure-u-1.pure-u-md-4-4
         != partial('_partial/footer.pug')
 
-    include _partial/totop.pug
+    if config.totop
+      include _partial/totop.pug
     include _partial/after_footer.pug

--- a/layout/base.pug
+++ b/layout/base.pug
@@ -42,5 +42,6 @@ html(lang=config.language)
       .pure-u-1.pure-u-md-3-4
         != partial('_partial/footer.pug')
 
-    include _partial/totop.pug
+    if config.totop
+      include _partial/totop.pug
     include _partial/after_footer.pug


### PR DESCRIPTION
This adds an option to remove the to-top rocket ship link from the bottom right of the page. I also fixed a typo in the config file since I was already there.