### PR TITLE
新增detailInfo侧边栏挂件widget

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -60,7 +60,7 @@ swiftype: ## Your swiftype_key, e.g. m7b11ZrsT8Me7gzApciT
 self_search: false ## Use a jQuery-based local search engine, true/false.
 google_analytics: ## Your Google Analytics tracking id, e.g. UA-42425684-2
 baidu_analytics: ## Your Baidu Analytics tracking id, e.g. 8006843039519956000
-microsoft_clarity:  ## Your Microsoft Clarity tracking id, e.g. zg2ctuea9j
+microsoft_clarity: ## Your Microsoft Clarity tracking id, e.g. zg2ctuea9j
 fancybox: true ## If you want to use fancybox please set the value to true.
 show_category_count: false ## If you want to show the count of categories in the sidebar widget please set the value to true.
 toc_number: true ## If you want to add list number to toc please set the value to true.
@@ -111,11 +111,30 @@ menu:
 
 widgets: ## Six widgets in sidebar provided: search, category, tag, recent_posts, recent_comments and links.
   - search
+  - detailInfo # 新增的widget
   - category
   - tag
   - recent_posts
   - recent_comments
   - links
+
+# widgetinfo
+widgetinfo:
+  avatar: /images/avatar.png #可以直接将头像放在source/下，也可以用图床链接套个url(),这里选择的是前者
+  discription: 今日事，今日毕
+  outlinkitem:
+    - name: steam
+      outlink: http://www.example1.com/
+      message: Nikki's Steam page
+    - name: envelope
+      outlink: 123@qq.com
+      message: xxx
+    - name: github
+      outlink: http://www.example1.com/
+      message: xxx Github page
+    - name: rss
+      outlink: atom.xml
+      message: xxx Blog的rss
 
 links:
   - title: site-name1

--- a/layout/_widget/detailInfo.pug
+++ b/layout/_widget/detailInfo.pug
@@ -1,0 +1,8 @@
+.widget
+  .author-info
+    a.info-avatar(href="/about/" title="Nikki")
+        img(src=theme.widgetinfo.avatar)
+    p #{theme.widgetinfo.discription}
+    - for (var i in theme.widgetinfo.outlinkitem)
+        a.info-icon(href=theme.widgetinfo.outlinkitem[i].outlink, title=theme.widgetinfo.outlinkitem[i].message, target='_blank',style='margin-inline:5px')  
+            i.fa(class="fa-"+theme.widgetinfo.outlinkitem[i].name+"-square"  style='margin-inline:5px')

--- a/source/css/style.scss
+++ b/source/css/style.scss
@@ -192,6 +192,24 @@ div {
                 box-shadow: none;
             }
         }
+        
+        // 个人信息widget样式
+        .author-info{
+            text-align: center;
+            a.info-avatar{
+                img{
+                    border-radius: 50%;
+                    padding: 4px;
+                    width: 96px;
+                    height: 96px;
+                    background-color: #fff;
+                    box-shadow:0 0 10px rgba(0, 0, 0, .2);
+                }
+            }
+            a.info-icon{
+                font-size: 25px;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
新增detailInfo侧边栏挂件widget，支持展示：
- [x] 圆形头像
- [x] 简短个人说明
- [x] 联系方式图标（默认steam、github、email、rss）

大佬酌情merge

