### PR TITLE
fix: #520,#223,修复首页文章展示异常

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -97,6 +97,7 @@ copycode: true ## If you want to enable one-click copy of the code blocks, set t
 dark: false ## If you want to toggle between light/dark themes, set the value to true.
 totop: true ## If you want to use the rocketship button to return to the top, set the value to true.
 external_css: false ## If you want to load an external CSS file, set the value to true and create a file named "external.css" in the source/css folder.
+post_content_length: 180 ## Set the length of characters displayed on the home page
 
 menu:
   - page: home

--- a/layout/index.pug
+++ b/layout/index.pug
@@ -11,7 +11,7 @@ block content
     .post
       h1.post-title
         if post.sticky
-          span(class="top-post")= __('Sticky') 
+          span(class="top-post")= __('Sticky')
         include _partial/helpers.pug
         a(href=url_for(post.path))
           +title(post)
@@ -29,20 +29,11 @@ block content
         .post-content
           != post.excerpt
       else if post.content
-        - var br = 0
-        - for (var i = 0; i < 5; ++i) {
-          - br = post.content.indexOf('\n',br+1)
-          if br<0
-            - break
-          if br >150
-            - break
-        - }
-        if br < 0
-          .post-content
-            != post.content
-        else
-          .post-content
-            != post.content.substring(0, br)
+        - const content = strip_html(post.content)
+        - let expert = content.substring(0,theme.post_content_length)
+        - content.length > theme.post_content_length ? expert += '...' : ''
+        .post-content
+          != expert
       p.readmore
         a(href=url_for(post.path))= __('Readmore')
 


### PR DESCRIPTION
之前的首页文章展示逻辑是暴力截取html文档，导致html标签被截断以至于后面的样式显示异常。
主题想要默认展示文章的第一段也很难做到，因为用'\n'作为第一段的分割点不合理，不是所有的markdown第一段都是文字，可能是代码块，可能是表格或者数学公式，当使用暴力截取这些内容的时候就很容易出现样式错误。
#520  这里出现的问题就是table标签被截断导致。
#223 出现的问题同样是因为上面的问题，而不是设置per_page导致，有的人可能第一篇文章没有被截断，而第二篇文章碰巧被截断了，有的人第八篇才被截断而导致。
hexo官方提供了辅助函数strip_html，可以用来处理这个问题。