### PR TITLE
修正使用 Waline 时的评论计数部件链接

### DIFF
--- a/layout/post.pug
+++ b/layout/post.pug
@@ -31,7 +31,7 @@ block content
         span.valine-comment-count(data-xid=url_for(page.path))
         span= ' ' + __('Comment')
     if theme.waline.enable == true
-      a.disqus-comment-count(href=url_for(page.path) + '#vcomment')
+      a.disqus-comment-count(href=url_for(page.path) + '#waline')
         span.waline-comment-count(id=url_for(page.path))
         span= ' ' + __('Comment')
     if page.toc


### PR DESCRIPTION
当前链接到 Valine 的 `#vcomment`，点击计数部件不能跳转到评论区，故改为 `#waline`。