### PR TITLE
fix: tag links not ending with '/'

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install theme and renderers:
 ```shell
 $ git clone https://github.com/tufu9441/maupassant-hexo.git themes/maupassant
 $ npm install hexo-renderer-pug --save
-$ npm install hexo-renderer-sass --save
+$ npm install hexo-renderer-sass-next --save
 ```
 
 Then change your `theme` setting in `_config.yml` to `maupassant`.

--- a/layout/_partial/tag.pug
+++ b/layout/_partial/tag.pug
@@ -1,5 +1,5 @@
 if page.tags
   .tags
     for tag in page.tags.toArray()
-      a(href=url_for(config.tag_dir) + '/' + tag.name)
+      a(href=url_for(config.tag_dir) + '/' + tag.name + '/')
         i.fa.fa-tag= tag.name


### PR DESCRIPTION
fix #547 ，hexo在打包的时候会给每一篇文章生成一个同名文件夹，文件夹下的inex.html才是文档本身。
带'/'默认为目录，不带'/'默认为文件。
结尾不带'/'，服务器会搜寻指定路径的文件，搜寻不到文件后，会重定向到对应的同名文件夹下进行查找，导致多触发一次重定向。