### PR TITLE
add serverURLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,7 @@ valine: ## See: https://valine.js.org
   enable: false ## If you want to use Valine comment system, please set the value to true.
   appid: ## Your LeanCloud application App ID, e.g. pRBBL2JR4N7kLEGojrF0MsSs-gzGzoHsz
   appkey: ## Your LeanCloud application App Key, e.g. tjczHpDfhjYDSYddzymYK1JJ
+  serverURLs: ## If you are the "LeanCloud" in China, then this option is not mandatory to fill out. REST API Server Url" of your "LeanCloud, e.g. https://prbbl2jr.api.lncldglobal.com
   notify: false ## Mail notifier, see https://github.com/xCss/Valine/wiki/Valine-评论系统中的邮件提醒设置
   verify: false ## Validation code.
   placeholder: Just so so ## Comment box placeholders.

--- a/layout/_partial/comments.pug
+++ b/layout/_partial/comments.pug
@@ -122,6 +122,7 @@ if theme.valine.enable == true
       verify:verify,
       appId:'#{theme.valine.appid}',
       appKey:'#{theme.valine.appkey}',
+      serverURLs:'#{theme.valine.serverURLs}',
       placeholder:'#{theme.valine.placeholder}',
       avatar:'#{theme.valine.avatar}',
       guest_info:guest_info,


### PR DESCRIPTION
對應 Issues #550

"valine"使用國際版的"LeanCloud"，在 `new Valine` 的時候必須携帶上 `serverURLs` 參數（在 `LeanCloud控制臺-應用憑證-服務器地址` 可以獲取這個參數）。

已對我的修改做過測試，如果用戶是使用中國版的LeanCloud，則 `_config.yml` 的 `valine->serverURLs` 可以讓用戶根據自己的需求選擇填寫或者留空。