### PR TITLE
修复fancybox问题

### DIFF
--- a/source/js/fancybox.js
+++ b/source/js/fancybox.js
@@ -11,9 +11,9 @@ $(document).ready(function() {
   });
 });
 $(document).ready(function() {
-  $("a[href$='.jpeg'],a[href$='.jpg'],a[href$='.png'],a[href$='.gif'],a[href$='.webp']").attr('rel', 'gallery').fancybox({
+  $("a[href$='.jpeg' i],a[href$='.jpg' i],a[href$='.png' i],a[href$='.gif' i],a[href$='.webp' i]").attr('data-fancybox', 'gallery').fancybox({
     helpers : {
-    title: { type: 'inside'}
+      title: { type: 'inside'}
     }
   });
 });


### PR DESCRIPTION
1.修复fancybox 上一张下一张箭头无法显示问题，目前版本已经不支持rel属性，需要使用data-fancybox属性。
2.兼容JPG大写图片格式。
